### PR TITLE
feat: model initial dev semantic

### DIFF
--- a/src/lib/conventional-commit.ts
+++ b/src/lib/conventional-commit.ts
@@ -6,22 +6,31 @@ import * as Semver from './semver'
  * changes should be. Returns `null` if all changes were meta or unconforming.
  */
 export function calcBumpType(
+  isInitialDevelopment: boolean,
   commitMessages: string[]
 ): null | Semver.MajMinPat {
   let semverPart: null | Semver.MajMinPat = null
   for (const m of commitMessages) {
     const cc = parse(m)
+
     // Commits that do not conform to conventional commit standard are discarded
     if (!cc) continue
 
-    // chore type commits are considered to not change the runtime in any way
+    // Completing initial development is a spec extension
+    // https://github.com/conventional-commits/conventionalcommits.org/pull/214
+    // with
+    if (isInitialDevelopment && cc.completesInitialDevelopment) return 'major'
+
     if (isMetaChange(cc)) {
+      // chore type commits are considered to not change the runtime in any way
       continue
     }
 
     // Nothing can be be higher so we've reached our final value effectively.
     if (cc.breakingChange) {
-      semverPart = 'major'
+      // during initial development breaking changes are permitted without
+      // having to bump the major.
+      semverPart = isInitialDevelopment ? 'minor' : 'major'
       break
     }
 
@@ -32,7 +41,11 @@ export function calcBumpType(
 
     if (isMinorChange(cc)) {
       semverPart = 'minor'
-      continue
+      // during initial development breaking changes are permitted without
+      // having to bump the major. Therefore, we know we won't get a bunmpType
+      // higher than this, can short-circuit.
+      if (isInitialDevelopment) break
+      else continue
     }
 
     semverPart = 'patch'
@@ -49,13 +62,14 @@ function isMetaChange(conventionalCommit: ConventionalCommit): boolean {
   return ['chore'].includes(conventionalCommit.type)
 }
 
-type ConventionalCommit = {
+export type ConventionalCommit = {
   type: string
   scope: null | string
   description: string
   body: null | string
   breakingChange: null | string
   footers: { type: string; body: string }[]
+  completesInitialDevelopment: boolean
 }
 
 const pattern = /^([^:\v(]+)(?:\(([^\v()]+)\))?:\s*([^\n]+)(?:\n\n((?:.|\n)+))?$/
@@ -65,6 +79,7 @@ export function parse(message: string): null | ConventionalCommit {
   if (!result) return null
   const [, type, scope, description, rest] = result
 
+  let completesInitialDevelopment = false
   let breakingChange = null
   let body = null
   let footers: ConventionalCommit['footers'] = []
@@ -75,13 +90,15 @@ export function parse(message: string): null | ConventionalCommit {
     let currFooter = -1
     let currSection = 'body'
     for (const para of rest.split(/\n\n/)) {
-      if (para.match(/^\s*BREAKING[-\s]CHANGE\s*:\s*.+/)) {
+      if (para.match(/\s*COMPLETES[-\s]INITIAL[-\s]DEVELOPMENT\s*/)) {
+        completesInitialDevelopment = true
+      } else if (para.match(/^\s*BREAKING[-\s]CHANGE\s*:\s*.*/)) {
         currSection = 'breaking_change'
         breakingChange =
           (breakingChange ?? '') +
           '\n\n' +
           para.replace(/^\s*BREAKING[-\s]CHANGE\s*:\s*/, '')
-      } else if (para.match(/^\s*[\w-]+\s*:\s*.+/)) {
+      } else if (para.match(/^\s*[\w-]+\s*:\s*.*/)) {
         currSection = 'footers'
         rawFooters.push(para)
         currFooter++
@@ -110,5 +127,6 @@ export function parse(message: string): null | ConventionalCommit {
     body: body?.trim() ?? null,
     footers: footers ?? [],
     breakingChange: breakingChange?.trim() ?? null,
+    completesInitialDevelopment,
   }
 }

--- a/src/utils/__snapshots__/release.spec.ts.snap
+++ b/src/utils/__snapshots__/release.spec.ts.snap
@@ -6,7 +6,18 @@ exports[`buildSeries none 1`] = `
 Object {
   "commitsInNextPreview": Array [
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -17,7 +28,18 @@ Object {
   ],
   "commitsInNextStable": Array [
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -27,7 +49,18 @@ Object {
     },
   ],
   "current": Object {
-    "message": "fix: thing 1",
+    "message": Object {
+      "parsed": Object {
+        "body": null,
+        "breakingChange": null,
+        "completesInitialDevelopment": false,
+        "description": "thing 1",
+        "footers": Array [],
+        "scope": null,
+        "type": "fix",
+      },
+      "raw": "fix: thing 1",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,
@@ -35,6 +68,8 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": true,
   "previousPreview": null,
   "previousStable": null,
 }
@@ -45,7 +80,10 @@ Object {
   "commitsInNextPreview": Array [],
   "commitsInNextStable": Array [
     Object {
-      "message": "foo @ 0.0.0-next.1",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 0.0.0-next.1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -64,7 +102,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -74,7 +123,10 @@ Object {
     },
   ],
   "current": Object {
-    "message": "foo @ 0.0.0-next.1",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 0.0.0-next.1",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -92,8 +144,13 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": true,
   "previousPreview": Object {
-    "message": "foo @ 0.0.0-next.1",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 0.0.0-next.1",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -120,7 +177,10 @@ Object {
   "commitsInNextPreview": Array [],
   "commitsInNextStable": Array [
     Object {
-      "message": "foo @ 0.0.0-next.2",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 0.0.0-next.2",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -139,7 +199,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 2",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 2",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 2",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -148,7 +219,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -157,7 +239,10 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "foo @ 0.0.0-next.1",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 0.0.0-next.1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -177,7 +262,10 @@ Object {
     },
   ],
   "current": Object {
-    "message": "foo @ 0.0.0-next.2",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 0.0.0-next.2",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -195,8 +283,13 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": true,
   "previousPreview": Object {
-    "message": "foo @ 0.0.0-next.2",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 0.0.0-next.2",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -222,7 +315,18 @@ exports[`buildSeries stable none 1`] = `
 Object {
   "commitsInNextPreview": Array [
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -233,7 +337,18 @@ Object {
   ],
   "commitsInNextStable": Array [
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -243,7 +358,18 @@ Object {
     },
   ],
   "current": Object {
-    "message": "fix: thing 1",
+    "message": Object {
+      "parsed": Object {
+        "body": null,
+        "breakingChange": null,
+        "completesInitialDevelopment": false,
+        "description": "thing 1",
+        "footers": Array [],
+        "scope": null,
+        "type": "fix",
+      },
+      "raw": "fix: thing 1",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,
@@ -251,9 +377,14 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": false,
   "previousPreview": null,
   "previousStable": Object {
-    "message": "foo @ 1.0.0",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,
@@ -274,7 +405,18 @@ exports[`buildSeries stable none none preview none 1`] = `
 Object {
   "commitsInNextPreview": Array [
     Object {
-      "message": "fix: thing 3",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 3",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 3",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -285,7 +427,18 @@ Object {
   ],
   "commitsInNextStable": Array [
     Object {
-      "message": "fix: thing 3",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 3",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 3",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -294,7 +447,10 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "foo @ 1.0.0-next.1",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 1.0.0-next.1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -313,7 +469,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 2",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 2",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 2",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -322,7 +489,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -332,7 +510,18 @@ Object {
     },
   ],
   "current": Object {
-    "message": "fix: thing 3",
+    "message": Object {
+      "parsed": Object {
+        "body": null,
+        "breakingChange": null,
+        "completesInitialDevelopment": false,
+        "description": "thing 3",
+        "footers": Array [],
+        "scope": null,
+        "type": "fix",
+      },
+      "raw": "fix: thing 3",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,
@@ -340,8 +529,13 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": false,
   "previousPreview": Object {
-    "message": "foo @ 1.0.0-next.1",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0-next.1",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -360,7 +554,10 @@ Object {
     "sha": "sha",
   },
   "previousStable": Object {
-    "message": "foo @ 1.0.0",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,
@@ -382,7 +579,10 @@ Object {
   "commitsInNextPreview": Array [],
   "commitsInNextStable": Array [
     Object {
-      "message": "foo @ 1.0.0-next.4",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 1.0.0-next.4",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -401,7 +601,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 3",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 3",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 3",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -410,7 +621,10 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "foo @ 1.0.0-next.3",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 1.0.0-next.3",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -429,7 +643,10 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "foo @ 1.0.0-next.2",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 1.0.0-next.2",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -448,7 +665,10 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "foo @ 1.0.0-next.1",
+      "message": Object {
+        "parsed": null,
+        "raw": "foo @ 1.0.0-next.1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": Object {
@@ -467,7 +687,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 2",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 2",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 2",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -476,7 +707,18 @@ Object {
       "sha": "sha",
     },
     Object {
-      "message": "fix: thing 1",
+      "message": Object {
+        "parsed": Object {
+          "body": null,
+          "breakingChange": null,
+          "completesInitialDevelopment": false,
+          "description": "thing 1",
+          "footers": Array [],
+          "scope": null,
+          "type": "fix",
+        },
+        "raw": "fix: thing 1",
+      },
       "nonReleaseTags": Array [],
       "releases": Object {
         "preview": null,
@@ -486,7 +728,10 @@ Object {
     },
   ],
   "current": Object {
-    "message": "foo @ 1.0.0-next.4",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0-next.4",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -504,8 +749,13 @@ Object {
     },
     "sha": "sha",
   },
+  "hasBreakingChange": false,
+  "isInitialDevelopment": false,
   "previousPreview": Object {
-    "message": "foo @ 1.0.0-next.4",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0-next.4",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": Object {
@@ -524,7 +774,10 @@ Object {
     "sha": "sha",
   },
   "previousStable": Object {
-    "message": "foo @ 1.0.0",
+    "message": Object {
+      "parsed": null,
+      "raw": "foo @ 1.0.0",
+    },
     "nonReleaseTags": Array [],
     "releases": Object {
       "preview": null,

--- a/src/utils/release.spec.ts
+++ b/src/utils/release.spec.ts
@@ -5,8 +5,18 @@
 
 import * as Git from '../lib/git'
 import * as Rel from './release'
+import { inspect } from 'util'
 
-describe('buildSeries', () => {
+describe.only('buildSeries', () => {
+  it('one breaking change commit makes the series breaking', () => {
+    expect(gitlog(n, breaking, p).hasBreakingChange).toEqual(true)
+  })
+  it('tracks if is initial development', () => {
+    expect(gitlog(p).isInitialDevelopment).toEqual(true)
+  })
+  it('tracks if is not initial development', () => {
+    expect(gitlog(s, p).isInitialDevelopment).toEqual(false)
+  })
   it('<empty>', () => {
     expect(() => gitlog()).toThrowErrorMatchingSnapshot()
   })
@@ -46,12 +56,26 @@ beforeEach(() => {
   sMaj = 0
 })
 
+/**
+ * breaking change commit
+ */
+function breaking(): RawLogEntryValues {
+  const ver = `${sMaj}.0.0-next.${pNum}`
+  return ['sha', `tag: ${ver}`, `foo: bar\n\nBREAKING CHANGE: foo`]
+}
+
+/**
+ * preview-released commit
+ */
 function p(): RawLogEntryValues {
   pNum++
   const ver = `${sMaj}.0.0-next.${pNum}`
   return ['sha', `tag: ${ver}`, `foo @ ${ver}`]
 }
 
+/**
+ * stable-released commit
+ */
 function s(): RawLogEntryValues {
   sMaj++
   pNum = 0
@@ -59,6 +83,9 @@ function s(): RawLogEntryValues {
   return ['sha', `tag: ${ver}`, `foo @ ${ver}`]
 }
 
+/**
+ * unreleaesd commit
+ */
 function n(): RawLogEntryValues {
   return ['sha', '', `fix: thing ${noneCounter++}`]
 }

--- a/src/utils/release.spec.ts
+++ b/src/utils/release.spec.ts
@@ -5,9 +5,8 @@
 
 import * as Git from '../lib/git'
 import * as Rel from './release'
-import { inspect } from 'util'
 
-describe.only('buildSeries', () => {
+describe('buildSeries', () => {
   it('one breaking change commit makes the series breaking', () => {
     expect(gitlog(n, breaking, p).hasBreakingChange).toEqual(true)
   })

--- a/tests/commands/preview.spec.ts
+++ b/tests/commands/preview.spec.ts
@@ -75,7 +75,18 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "minor",
           "commits": Array [
-            "feat: ti ti ti",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "ti ti ti",
+                "footers": Array [],
+                "scope": null,
+                "type": "feat",
+              },
+              "raw": "feat: ti ti ti",
+            },
           ],
           "version": "0.2.0-next.2",
         },
@@ -93,10 +104,46 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "patch",
           "commits": Array [
-            "fix: 1",
-            "chore: add package.json",
-            "chore: who knows",
-            "Initial commit",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "add package.json",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: add package.json",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "who knows",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: who knows",
+            },
+            Object {
+              "parsed": null,
+              "raw": "Initial commit",
+            },
           ],
           "version": "0.0.1-next.1",
         },
@@ -114,10 +161,46 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "minor",
           "commits": Array [
-            "feat: 1",
-            "chore: add package.json",
-            "chore: who knows",
-            "Initial commit",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "feat",
+              },
+              "raw": "feat: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "add package.json",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: add package.json",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "who knows",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: who knows",
+            },
+            Object {
+              "parsed": null,
+              "raw": "Initial commit",
+            },
           ],
           "version": "0.1.0-next.1",
         },
@@ -136,11 +219,58 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "minor",
           "commits": Array [
-            "feat: 1",
-            "fix: 1",
-            "chore: add package.json",
-            "chore: who knows",
-            "Initial commit",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "feat",
+              },
+              "raw": "feat: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "add package.json",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: add package.json",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "who knows",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: who knows",
+            },
+            Object {
+              "parsed": null,
+              "raw": "Initial commit",
+            },
           ],
           "version": "0.1.0-next.1",
         },
@@ -161,19 +291,77 @@ describe('stable preview releases', () => {
     expect(result).toMatchInlineSnapshot(`
       Object {
         "data": Object {
-          "bumpType": "major",
+          "bumpType": "minor",
           "commits": Array [
-            "feat: 2
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": "blah blah blah",
+                "completesInitialDevelopment": false,
+                "description": "2",
+                "footers": Array [],
+                "scope": null,
+                "type": "feat",
+              },
+              "raw": "feat: 2
 
       BREAKING CHANGE:
       blah blah blah",
-            "feat: 1",
-            "fix: 1",
-            "chore: add package.json",
-            "chore: who knows",
-            "Initial commit",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "feat",
+              },
+              "raw": "feat: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 1",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "add package.json",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: add package.json",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "who knows",
+                "footers": Array [],
+                "scope": null,
+                "type": "chore",
+              },
+              "raw": "chore: who knows",
+            },
+            Object {
+              "parsed": null,
+              "raw": "Initial commit",
+            },
           ],
-          "version": "1.0.0-next.1",
+          "version": "0.1.0-next.1",
         },
         "kind": "ok",
         "type": "dry_run",
@@ -195,8 +383,30 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "patch",
           "commits": Array [
-            "fix: 2",
-            "fix: 1",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "2",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 2",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "1",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 1",
+            },
           ],
           "version": "0.1.1-next.1",
         },
@@ -217,8 +427,30 @@ describe('stable preview releases', () => {
         "data": Object {
           "bumpType": "patch",
           "commits": Array [
-            "fix: 3",
-            "fix: 2",
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "3",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 3",
+            },
+            Object {
+              "parsed": Object {
+                "body": null,
+                "breakingChange": null,
+                "completesInitialDevelopment": false,
+                "description": "2",
+                "footers": Array [],
+                "scope": null,
+                "type": "fix",
+              },
+              "raw": "fix: 2",
+            },
           ],
           "version": "0.0.1-next.2",
         },

--- a/tests/commands/stable.spec.ts
+++ b/tests/commands/stable.spec.ts
@@ -140,8 +140,30 @@ describe('increments upon the previous stable release based on conventional comm
         "data": Object {
           "context": Object {
             "commits": Array [
-              "chore: 2",
-              "chore: 1",
+              Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "2",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "chore",
+                },
+                "raw": "chore: 2",
+              },
+              Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "1",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "chore",
+                },
+                "raw": "chore: 1",
+              },
             ],
           },
           "summary": "The release you attempting only contains chore commits which means no release is needed.",
@@ -164,9 +186,21 @@ describe('increments upon the previous stable release based on conventional comm
     expect(result).toMatchInlineSnapshot(`
       Object {
         "data": Object {
+          "bumpType": "patch",
           "commits": Array [
             Object {
-              "message": "fix: 2",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "2",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "fix",
+                },
+                "raw": "fix: 2",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -175,7 +209,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "fix: 1",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "1",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "fix",
+                },
+                "raw": "fix: 1",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -184,7 +229,13 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
           ],
-          "newVer": "0.1.1",
+          "version": Object {
+            "major": 0,
+            "minor": 1,
+            "patch": 1,
+            "version": "0.1.1",
+            "vprefix": false,
+          },
         },
         "kind": "ok",
         "type": "dry_run",
@@ -205,9 +256,21 @@ describe('increments upon the previous stable release based on conventional comm
     expect(result).toMatchInlineSnapshot(`
       Object {
         "data": Object {
+          "bumpType": "minor",
           "commits": Array [
             Object {
-              "message": "feat: 2",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "2",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "feat",
+                },
+                "raw": "feat: 2",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -216,7 +279,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "chore: 1",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "1",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "chore",
+                },
+                "raw": "chore: 1",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -225,7 +299,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "fix: 1",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "1",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "fix",
+                },
+                "raw": "fix: 1",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -234,7 +319,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "feat: 1",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "1",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "feat",
+                },
+                "raw": "feat: 1",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -243,7 +339,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "chore: add package.json",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "add package.json",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "chore",
+                },
+                "raw": "chore: add package.json",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -252,7 +359,18 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "chore: who knows",
+              "message": Object {
+                "parsed": Object {
+                  "body": null,
+                  "breakingChange": null,
+                  "completesInitialDevelopment": false,
+                  "description": "who knows",
+                  "footers": Array [],
+                  "scope": null,
+                  "type": "chore",
+                },
+                "raw": "chore: who knows",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -261,7 +379,10 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
             Object {
-              "message": "Initial commit",
+              "message": Object {
+                "parsed": null,
+                "raw": "Initial commit",
+              },
               "nonReleaseTags": Array [],
               "releases": Object {
                 "preview": null,
@@ -270,7 +391,13 @@ describe('increments upon the previous stable release based on conventional comm
               "sha": "__sha__",
             },
           ],
-          "newVer": "0.1.0",
+          "version": Object {
+            "major": 0,
+            "minor": 1,
+            "patch": 0,
+            "version": "0.1.0",
+            "vprefix": false,
+          },
         },
         "kind": "ok",
         "type": "dry_run",


### PR DESCRIPTION
closes #31 

Based on ideas being slowly discussed at spec level here:
https://github.com/conventional-commits/conventionalcommits.org/pull/214

BREAKING CHANGE:
- To go from 0.x to 1.x it is now required to use the special keyphrase:

    `COMPLETES INITIAL DEVELOPMENT`