### PR TITLE
chore(deps)!: drop node 10 / add node 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,7 +30,7 @@ jobs:
         run: git fetch --prune --unshallow --tags
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: yarn --frozen-lockfile
       - run: yarn -s dripip preview-or-pr
         env:


### PR DESCRIPTION
Node 10 isn't compatible w/ `chaindown@0.1.0-next.1`:
> error chaindown@0.1.0-next.1: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.23.2"

https://github.com/prisma-labs/dripip/pull/108/checks?check_run_id=1905578255